### PR TITLE
Add option to set token or uid/pwd for shock admin creds.

### DIFF
--- a/deploy.cfg
+++ b/deploy.cfg
@@ -7,9 +7,11 @@ service-port = 9001
 
 handle-service-url = https://kbase.us/services/handle_service
 
-# to run the handle manager as admin user in shock
+# to run the handle manager as admin user in shock. Supply either a uid/pwd or
+# a token.
 admin-login    = 
 admin-password = 
+admin-token    = 
 
 #kbase users that have permissions to run add_read_acl and set_public_read,
 # separated by commas

--- a/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
+++ b/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
@@ -53,13 +53,18 @@ sub new
 		print STDERR "Can't find config.\n" ;
 	}
 
-	my $login    = $cfg->param('HandleMngr.admin-login');
+	my $login = $cfg->param('HandleMngr.admin-login');
 	if (ref $login eq 'ARRAY') {
 		$login = undef;
 	}
 	my $password = $cfg->param('HandleMngr.admin-password');
 	if (ref $password eq 'ARRAY') {
 		$password = undef;
+	}
+
+	my $token = $cfg->param('HandleMngr.admin-token');
+	if (ref $token eq 'ARRAY') {
+		$token = undef;
 	}
 	
 	$self->{handle_url} = $cfg->param('HandleMngr.handle-service-url');
@@ -77,12 +82,20 @@ sub new
 	print STDERR "Allowed users: [" . join(" ", @{$self->{allowed_users}}) . "]\n";
 		
 	print STDERR "Creating admin token\n" ;
-	my $token = Bio::KBase::AuthToken->new(
+	my $authtoken;
+	if ($token) {
+		$authtoken = Bio::KBase::AuthToken->new(token => $token);
+		if (!$authtoken->validate()) {
+			die "Login with admin-token failed: " . $authtoken->error_message;
+		}
+	} else {
+		$authtoken = Bio::KBase::AuthToken->new(
 		user_id => $login, password => $password);
-	if (!defined($token->token())) {
+	}
+	if (!defined($authtoken->token())) {
 		die "Login as $login failed.\n";
 	} else {
-		$self->{'admin-token'} = $token->token();
+		$self->{'admin-token'} = $authtoken->token();
 	}
 
     #END_CONSTRUCTOR


### PR DESCRIPTION
Tested by running the workspace handle test suite using a token.