### PR TITLE
TASK-722 Patch for reading ACLs before attempting to modify

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,3 @@
+02 May 2017
+
+* Bug fixes for TASK-722, compare current ACL before calling PUT to shock-api.

--- a/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
+++ b/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
@@ -327,6 +327,27 @@ sub add_read_acl
 
 		my $header = HTTP::Headers->new('Authorization' => "OAuth " . $admin_token) ;
 
+                $ua->default_headers($header);
+
+                my $getResult = $ua->get($nodeurl."/acl?verbosity=full");
+                if (!$getResult->is_success) {
+			$succeeded{$handle->{hid}} = 0;
+			warn "Error: " . $getResult->message;
+			warn "Error: " . $getResult->content;
+                        next;                    
+                }
+                
+                my $jsonUsers=from_json($getResult->content);
+                my $users=$jsonUsers->{'data'}{'read'};
+                
+                if (grep { $_->{'username'} eq $username } @$users) {
+		    $succeeded{$handle->{hid}} = 1;
+                    warn "$username already has read access on $nodeurl, skipping PUT";
+                    next;
+                }
+
+                warn "setting read ACL on $nodeurl for $username";
+
 		my $req = new HTTP::Request("PUT",$nodeurl."/acl/read?users=$username",HTTP::Headers->new('Authorization' => "OAuth " . $admin_token));
 		$ua->prepare_request($req);
 		my $put = $ua->send_request($req);

--- a/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
+++ b/lib/Bio/KBase/HandleMngr/HandleMngrImpl.pm
@@ -461,7 +461,7 @@ sub set_public_read
 	my %succeeded;
 	foreach my $handle (@$handles) {
 
-		my $nodeurl = $handle->{url} . '/node/' . $handle->{id} . "/acl/public_read";
+		my $nodeurl = $handle->{url} . '/node/' . $handle->{id};
 		my $ua = LWP::UserAgent->new();
 
 		my $header = HTTP::Headers->new('Authorization' => "OAuth " . $admin_token) ;
@@ -486,7 +486,8 @@ sub set_public_read
 
                 warn "setting read ACL on $nodeurl for public";
 
-		my $req = new HTTP::Request("PUT", $nodeurl, HTTP::Headers->new('Authorization' => "OAuth " . $admin_token));
+		my $publicReadUrl = $handle->{url} . '/node/' . $handle->{id} . "/acl/public_read";
+		my $req = new HTTP::Request("PUT", $publicReadUrl, HTTP::Headers->new('Authorization' => "OAuth " . $admin_token));
 		$ua->prepare_request($req);
 		my $put = $ua->send_request($req);
 		if ($put->is_success) {


### PR DESCRIPTION
Look up the current ACLs for a node before attempting to PUT new ACLs (TASK-722).  Modifies add_read_acl and set_public_read.